### PR TITLE
check details.response.statusCode when error is falsy

### DIFF
--- a/test/registry.js
+++ b/test/registry.js
@@ -118,8 +118,8 @@ describe(`When connecting to registry ${url}`, () => {
       request({
         timeout,
         url: `https:${cdnUrl}oc-client/${ocClientVersion}/server.js`
-      }, (err, res) => {
-        expect(err).to.equal(403);
+      }, (err, res, details) => {
+        expect(err || details.response.statusCode).to.equal(403);
         done();
       });
     });


### PR DESCRIPTION
# Description

If response status is 200, `minimal-request` returns `null` as error. In order to have explicit feedback that a resource that should be forbidden is exposed instead, we need to check against the `details.response.statusCode`.

## Before

<img width="1172" alt="before" src="https://cloud.githubusercontent.com/assets/6423261/23821533/07aa04ee-05ea-11e7-91da-3c3e259eff20.png">

## After

<img width="1172" alt="after" src="https://cloud.githubusercontent.com/assets/6423261/23821534/0c025cd0-05ea-11e7-8c47-b759278ac535.png">
